### PR TITLE
Improvements made to scrolling feature

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -442,7 +442,6 @@ public:
 		orig_y = height / 2;
 		width -= border;
 		height -= border;
-		XFixesHideCursor(dpy, ROOT);
 		reset_position(true);
 	}
 	virtual void fake_wheel(int b1, int n1, int b2, int n2) {
@@ -468,7 +467,6 @@ public:
 		}
 	}
 	virtual void release(guint b, RTriple e) {
-		XFixesShowCursor(dpy, ROOT);
 		Handler *p = parent;
 		p->replace_child(NULL);
 		p->release(b, e);


### PR DESCRIPTION
The scrolling feature was limited to the current screen, and so any serious long-page scrolling came to a halt pretty quickly. Also, when you released the scroll button, the mouse would move to a new location, even if it was set to return to the original position. 

I fixed it by moving the cursor to the middle of the screen and resetting the cursor to the middle whenever it neared the screen edge. In addition, I added the code to reset the cursor to its original position.

Let me know what you think-- I'd at least like to get the fix updated on some level in the ubuntu repos. Thanks!
