### PR TITLE
Fix black squares on gnome3

### DIFF
--- a/composite.cc
+++ b/composite.cc
@@ -27,6 +27,7 @@ Popup::Popup(int x1, int y1, int x2, int y2) : Gtk::Window(Gtk::WINDOW_POPUP), r
 
 	Glib::RefPtr<Gdk::Visual> visual = get_screen()->get_rgba_visual();
 	gtk_widget_set_visual(Widget::gobj(), visual->gobj());
+	gtk_widget_set_app_paintable (Widget::gobj(), TRUE);
 	signal_draw().connect(sigc::mem_fun(*this, &Popup::on_draw));
 	realize();
 	move(x1, y1);


### PR DESCRIPTION
This small change gets rid of black squares on gnome 3
