### PR TITLE
Create easystroke.appdata.xml

### DIFF
--- a/easystroke.appdata.xml
+++ b/easystroke.appdata.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2014 Thomas Jaeger <ThJaeger@gmail.com> -->
+<component type="desktop">
+ <id>easystroke.desktop</id>
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license>ISC</project_license>
+ <name>Easystroke</name>
+ <summary>Gesture-recognition application for X11</summary>
+ <description>
+  <p>
+   Easystroke is a gesture-recognition application for X11. Gestures or strokes
+   are movements that you make with you mouse (or your pen, finger etc.) while
+   holding down a specific mouse button. Easystroke will execute certain actions
+   if it recognizes the stroke; currently easystroke can emulate key presses,
+   execute shell commands, hold down modifiers and emulate a scroll wheel.
+  </p>
+  <p>
+   The program was designed with Tablet PCs in mind and can be used effectively
+   even without access to a keyboard. Easystroke tries to provide an intuitive
+   and efficient user interface, while at the same time being highly configurable
+   and offering many advanced features.
+  </p>
+ </description>
+ <screenshots>
+  <screenshot type="default">
+   <image width="1024" height="576">
+    https://alexpl.fedorapeople.org/AppData/easystroke/screens/easystroke_01.png
+   </image>
+  </screenshot>
+  <screenshot>
+   <image width="1024" height="576">
+    https://alexpl.fedorapeople.org/AppData/easystroke/screens/easystroke_02.png
+   </image>
+  </screenshot>
+  <screenshot>
+   <image width="1024" height="576">
+    https://alexpl.fedorapeople.org/AppData/easystroke/screens/easystroke_03.png
+   </image>
+  </screenshot>
+ </screenshots>
+ <url type="homepage">https://github.com/thjaeger/easystroke/wiki</url>
+ <updatecontact>ThJaeger@gmail.com</updatecontact>
+</component>


### PR DESCRIPTION
Hello,

I've been a long time fan of easystroke, ever since I got all the buttons on my MX 1000 and Performance MX mice working just the way I wanted them.

You may have learned about the upcoming software centers in GNOME and KDE. These require an appdata file [1], [2] to be installed in /usr/share/appdata/ similar to the way .desktop files are placed in /usr/share/applications/, e.g. if you have a "$(datadir)/applications" definition in your makefiles, you need to add a "$(datadir)/appdata" as well.

There is a pending proposal in Fedora to not include in the software center applications that do not provide such appdata.xml files, so I took the liberty to prepare one for easystroke -along with some screenshots- when I noticed it was on that list (I've been working with several upstream projects in the last few days to that end). Please consider using this file and screenshots or making your own, just make sure it passes validation. Also if you decide to use this file, take a quick look to see if I've missed something or if you'd rather use a different license.

Thanks for your great work!

[1] http://people.freedesktop.org/~hughsient/appdata/
[2] http://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html
