### PR TITLE
switch from fork to g_spawn_async

### DIFF
--- a/actiondb.cc
+++ b/actiondb.cc
@@ -119,14 +119,9 @@ template<class Archive> void StrokeInfo::serialize(Archive & ar, const unsigned 
 using namespace std;
 
 void Command::run() {
-	pid_t pid = fork();
-	switch (pid) {
-		case 0:
-			execlp("/bin/sh", "sh", "-c", cmd.c_str(), nullptr);
-			exit(1);
-		case -1:
-			printf(_("Error: can't execute command \"%s\": fork() failed\n"), cmd.c_str());
-	}
+	gchar* argv[] = {(gchar*) "/bin/sh", (gchar*) "-c", NULL, NULL};
+	argv[2] = (gchar *) cmd.c_str();
+	g_spawn_async(NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, NULL);
 }
 
 ButtonInfo Button::get_button_info() const {


### PR DESCRIPTION
I've been using easystroke with the bspwm window manager to create touchscreen actions (like draw a w to open a web browser etc).

It is working really well but I noticed I was ending up with a lot of zombie processes. Switching from fork to glib's g_spawn_async function as in this commit fixed this for me.
