### PR TITLE
Fix crash.

### DIFF
--- a/prefs.cc
+++ b/prefs.cc
@@ -426,6 +426,8 @@ void Prefs::on_edit_extra() {
 	etv->get_cursor(path, col);
 	if (!path.gobj())
 		return;
+	if (path.empty())
+		return;
 	Gtk::TreeIter iter = *etm->get_iter(path);
 	std::vector<ButtonInfo>::iterator i = (*iter)[ecs.i];
 	SelectButton sb(*i, true, true);
@@ -447,6 +449,8 @@ void Prefs::on_remove_extra() {
 	Gtk::TreeViewColumn *col;
 	etv->get_cursor(path, col);
 	if (!path.gobj())
+		return;
+	if (path.empty())
 		return;
 	Gtk::TreeIter iter = *etm->get_iter(path);
 	Atomic a;


### PR DESCRIPTION
Hello.

I use easystroke conveniently. Thank you.

I found a problem that easystroke can crash.
How to reproduce:
1. Open easystroke pref window.
2. Show Prefercnes and click [Behavior]-[Additional Buttons]-([Edit] or [Remove]) without selecting a button.

Actual results:
Easystroke crashes with following messages;

> (easystroke:22138): Gtk-CRITICAL **: gtk_tree_model_get_iter: assertion 'path->depth > 0' failed
> 
> (easystroke:22138): Gtk-CRITICAL **: gtk_list_store_get_value: assertion 'iter_is_valid (iter, list_store)' failed
> [1]    22138 segmentation fault  ./easystroke

Expected results:
Easystroke doesn't crash.

I run easystroke on Debian jessie and build with gtk+3.0 version 3.14.5-1+deb8u1 and g++-4.9 version 4:4.9.2-2.  I am not much of a C++ and GTK, so modification might be incorrect(I tried to create an Issue, but couldn't).

Regards. 
