### PR TITLE
Remove unnecessary requirement for device to be absolute

### DIFF
--- a/actions.cc
+++ b/actions.cc
@@ -51,10 +51,11 @@ void TreeViewMulti::on_drag_begin(const Glib::RefPtr<Gdk::DragContext> &context)
 	context->set_icon(pb, pb->get_width(), pb->get_height());
 }
 
-bool negate(bool b) { return !b; }
-
 TreeViewMulti::TreeViewMulti() : Gtk::TreeView(), pending(false) {
-	get_selection()->set_select_function(sigc::group(&negate, sigc::ref(pending)));
+	get_selection()->set_select_function(
+		[this](Glib::RefPtr<Gtk::TreeModel> const&, Gtk::TreeModel::Path const&, bool) {
+			return !pending;
+		});
 }
 
 enum Type { COMMAND, KEY, TEXT, SCROLL, IGNORE, BUTTON, MISC };

--- a/gesture.cc
+++ b/gesture.cc
@@ -104,9 +104,9 @@ int Stroke::compare(RStroke a, RStroke b, double &score) {
 		return -1;
 	score = MAX(1.0 - 2.5*cost, 0.0);
 	if (a->timeout)
-		return score > 0.85;
+		return score > 0.95;
 	else
-		return score > 0.7;
+		return score > 0.92;
 }
 
 Glib::RefPtr<Gdk::Pixbuf> Stroke::draw(int size, double width, bool inv) const {

--- a/handler.cc
+++ b/handler.cc
@@ -563,7 +563,7 @@ protected:
 	}
 protected:
 	void move_back() {
-		if (!prefs.move_back.get() || (xstate->current_dev && xstate->current_dev->absolute))
+		if (!prefs.move_back.get())
 			return;
 		XTestFakeMotionEvent(dpy, DefaultScreen(dpy), orig_x, orig_y, 0);
 	}
@@ -968,7 +968,7 @@ protected:
 	virtual void release(guint b, RTriple e) {
 		RStroke s = finish(0);
 
-		if (prefs.move_back.get() && !xstate->current_dev->absolute)
+		if (prefs.move_back.get())
 			XTestFakeMotionEvent(dpy, DefaultScreen(dpy), orig->x, orig->y, 0);
 		else
 			XTestFakeMotionEvent(dpy, DefaultScreen(dpy), e->x, e->y, 0);


### PR DESCRIPTION
This changes will make easystroke work with mtrack touchpad driver.